### PR TITLE
chore: Update the Travis config to test over more platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 sudo: false
 language: node_js
+cache:
+   directories:
+      - node_modules
+notifications:
+   email: false
 node_js:
-   - stable
+   - '7'
+   - '6'
+   - '5'
+   - '4'
    - '0.12'
 script:
-   - npm run lint
-   - npm run mocha
+   - npm t
 env:
    - NODE_ENV=development
 install:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/cartridge/cartridge-module-util.git"
   },
   "scripts": {
-    "test": "node run lint && node run mocha",
+    "test": "npm run lint && mocha",
     "cover": "istanbul cover _mocha && open coverage/lcov-report/index.html",
     "lint": "eslint index.js",
     "mocha": "mocha"


### PR DESCRIPTION
Update the travis config so that it tests newer versions of Node.
Also stop sending emails after builds and start caching the node_modules dir to speed up the builds